### PR TITLE
Sprint 64

### DIFF
--- a/contrib/gtnap/.clang-format
+++ b/contrib/gtnap/.clang-format
@@ -27,6 +27,9 @@ arrst_foreach_const(.*)|\
 arrst_forback(.*)|\
 arrst_forback_const(.*)|\
 arrpt_foreach(.*)|\
+arrpt_foreach_const(.*)|\
+arrpt_forback(.*)|\
+arrpt_forback_const(.*)|\
 stm_lines(.*)|\
 setst_foreach(.*)|\
 setst_foreach_const(.*)|\

--- a/contrib/gtnap/src/draw2d/draw2d.c
+++ b/contrib/gtnap/src/draw2d/draw2d.c
@@ -114,14 +114,6 @@ void draw2d_finish(void)
 
 /*---------------------------------------------------------------------------*/
 
-void draw2d_user_monospace_family(const char_t *family)
-{
-    str_upd(&i_USER_MONOSPACE_FONT_FAMILY, family);
-    str_destopt(&i_MONOSPACE_FONT_FAMILY);
-}
-
-/*---------------------------------------------------------------------------*/
-
 uint32_t draw2d_register_font(const char_t *font_family)
 {
     /* Check if font name is a system font */
@@ -432,4 +424,12 @@ const char_t *draw2d_monospace_family(const char_t **desired_fonts, const uint32
     }
 
     return tc(i_MONOSPACE_FONT_FAMILY);
+}
+
+/*---------------------------------------------------------------------------*/
+
+void draw2d_preferred_monospace(const char_t *family)
+{
+    str_upd(&i_USER_MONOSPACE_FONT_FAMILY, family);
+    str_destopt(&i_MONOSPACE_FONT_FAMILY);
 }

--- a/contrib/gtnap/src/draw2d/draw2d.h
+++ b/contrib/gtnap/src/draw2d/draw2d.h
@@ -19,6 +19,4 @@ _draw2d_api void draw2d_start(void);
 
 _draw2d_api void draw2d_finish(void);
 
-_draw2d_api void draw2d_user_monospace_family(const char_t *family);
-
 __END_C

--- a/contrib/gtnap/src/draw2d/draw2d.hxx
+++ b/contrib/gtnap/src/draw2d/draw2d.hxx
@@ -49,7 +49,8 @@ typedef enum _fstyle_t
     ekFSUPSCRIPT = 32,
 
     ekFPIXELS = 0,
-    ekFPOINTS = 64
+    ekFPOINTS = 64,
+    ekFCELL = 128
 } fstyle_t;
 
 typedef enum _linecap_t

--- a/contrib/gtnap/src/draw2d/draw2d.inl
+++ b/contrib/gtnap/src/draw2d/draw2d.inl
@@ -24,6 +24,8 @@ void draw2d_extents_imp(void *data, FPtr_word_extents func_word_extents, const b
 
 const char_t *draw2d_monospace_family(const char_t **desired_fonts, const uint32_t n);
 
+void draw2d_preferred_monospace(const char_t *family);
+
 __END_C
 
 #define draw2d_extents(data, func_word_extents, newlines, str, refwidth, width, height, type) \

--- a/contrib/gtnap/src/draw2d/font.c
+++ b/contrib/gtnap/src/draw2d/font.c
@@ -243,6 +243,13 @@ void font_extents(const Font *font, const char_t *text, const real32_t refwidth,
 
 /*---------------------------------------------------------------------------*/
 
+void font_preferred_monospace(const char_t *family)
+{
+    draw2d_preferred_monospace(family);
+}
+
+/*---------------------------------------------------------------------------*/
+
 const void *font_native(const Font *font)
 {
     cassert_no_null(font);

--- a/contrib/gtnap/src/draw2d/font.h
+++ b/contrib/gtnap/src/draw2d/font.h
@@ -51,6 +51,8 @@ _draw2d_api bool_t font_is_monospace(const Font *font);
 
 _draw2d_api uint32_t font_style(const Font *font);
 
+_draw2d_api void font_set_width(Font *font, real32_t width);
+
 _draw2d_api void font_extents(const Font *font, const char_t *text, const real32_t refwidth, real32_t *width, real32_t *height);
 
 _draw2d_api bool_t font_exists_family(const char_t *family);

--- a/contrib/gtnap/src/draw2d/font.h
+++ b/contrib/gtnap/src/draw2d/font.h
@@ -59,6 +59,8 @@ _draw2d_api ArrPt(String) *font_installed_families(void);
 
 _draw2d_api ArrPt(String) *font_installed_monospace(void);
 
+_draw2d_api void font_preferred_monospace(const char_t *family);
+
 _draw2d_api const void *font_native(const Font *font);
 
 __END_C

--- a/contrib/gtnap/src/draw2d/font.inl
+++ b/contrib/gtnap/src/draw2d/font.inl
@@ -18,7 +18,7 @@ void osfont_alloc_globals(void);
 
 void osfont_dealloc_globals(void);
 
-OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t style);
+OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t width, const uint32_t style);
 
 void osfont_destroy(OSFont **font);
 

--- a/contrib/gtnap/src/draw2d/gtk/draw_gtk.c
+++ b/contrib/gtnap/src/draw2d/gtk/draw_gtk.c
@@ -562,6 +562,7 @@ void draw_font(DCtx *ctx, const Font *font)
             const PangoFontDescription *fdesc = (PangoFontDescription *)font_native(ctx->font);
             pango_layout_set_font_description(ctx->layout, fdesc);
 
+            /*
             // {
             // PangoMatrix matrix = PANGO_MATRIX_INIT;
             //     PangoContext *context = pango_layout_get_context(ctx->layout);
@@ -569,7 +570,7 @@ void draw_font(DCtx *ctx, const Font *font)
             //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
             //     pango_context_set_matrix(context, &matrix);
             // }
-
+*/
         }
     }
 }
@@ -599,6 +600,7 @@ static void i_begin_text(DCtx *ctx, const char_t *text, const real32_t x, const 
         ctx->layout = pango_cairo_create_layout(ctx->cairo);
         pango_layout_set_font_description(ctx->layout, fdesc);
 
+        /*
         // {
         //     PangoMatrix matrix = PANGO_MATRIX_INIT;
         //     PangoContext *context = pango_layout_get_context(ctx->layout);
@@ -607,7 +609,7 @@ static void i_begin_text(DCtx *ctx, const char_t *text, const real32_t x, const 
         //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
         //     pango_context_set_matrix(context, &matrix);
         // }
-
+        */
     }
 
     pango_layout_set_text(ctx->layout, (const char *)text, -1);
@@ -803,6 +805,7 @@ void draw_text_extents(DCtx *ctx, const char_t *text, const real32_t refwidth, r
         ctx->layout = pango_cairo_create_layout(ctx->cairo);
         pango_layout_set_font_description(ctx->layout, fdesc);
 
+        /*
         // {
         //     PangoMatrix matrix = PANGO_MATRIX_INIT;
         //     PangoContext *context = pango_layout_get_context(ctx->layout);
@@ -811,7 +814,7 @@ void draw_text_extents(DCtx *ctx, const char_t *text, const real32_t refwidth, r
         //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
         //     pango_context_set_matrix(context, &matrix);
         // }
-
+        */
     }
 
     pango_layout_set_text(ctx->layout, (const char *)text, -1);

--- a/contrib/gtnap/src/draw2d/gtk/draw_gtk.c
+++ b/contrib/gtnap/src/draw2d/gtk/draw_gtk.c
@@ -561,6 +561,15 @@ void draw_font(DCtx *ctx, const Font *font)
         {
             const PangoFontDescription *fdesc = (PangoFontDescription *)font_native(ctx->font);
             pango_layout_set_font_description(ctx->layout, fdesc);
+
+            // {
+            // PangoMatrix matrix = PANGO_MATRIX_INIT;
+            //     PangoContext *context = pango_layout_get_context(ctx->layout);
+            //     pango_matrix_rotate(&matrix, 10);
+            //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
+            //     pango_context_set_matrix(context, &matrix);
+            // }
+
         }
     }
 }
@@ -589,6 +598,16 @@ static void i_begin_text(DCtx *ctx, const char_t *text, const real32_t x, const 
         fdesc = (PangoFontDescription *)font_native(ctx->font);
         ctx->layout = pango_cairo_create_layout(ctx->cairo);
         pango_layout_set_font_description(ctx->layout, fdesc);
+
+        // {
+        //     PangoMatrix matrix = PANGO_MATRIX_INIT;
+        //     PangoContext *context = pango_layout_get_context(ctx->layout);
+        //     pango_matrix_rotate(&matrix, 10);
+
+        //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
+        //     pango_context_set_matrix(context, &matrix);
+        // }
+
     }
 
     pango_layout_set_text(ctx->layout, (const char *)text, -1);
@@ -783,6 +802,16 @@ void draw_text_extents(DCtx *ctx, const char_t *text, const real32_t refwidth, r
         fdesc = (PangoFontDescription *)font_native(ctx->font);
         ctx->layout = pango_cairo_create_layout(ctx->cairo);
         pango_layout_set_font_description(ctx->layout, fdesc);
+
+        // {
+        //     PangoMatrix matrix = PANGO_MATRIX_INIT;
+        //     PangoContext *context = pango_layout_get_context(ctx->layout);
+        //     pango_matrix_rotate(&matrix, 10);
+
+        //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
+        //     pango_context_set_matrix(context, &matrix);
+        // }
+
     }
 
     pango_layout_set_text(ctx->layout, (const char *)text, -1);

--- a/contrib/gtnap/src/draw2d/gtk/draw_gtk.c
+++ b/contrib/gtnap/src/draw2d/gtk/draw_gtk.c
@@ -561,16 +561,6 @@ void draw_font(DCtx *ctx, const Font *font)
         {
             const PangoFontDescription *fdesc = (PangoFontDescription *)font_native(ctx->font);
             pango_layout_set_font_description(ctx->layout, fdesc);
-
-            /*
-            // {
-            // PangoMatrix matrix = PANGO_MATRIX_INIT;
-            //     PangoContext *context = pango_layout_get_context(ctx->layout);
-            //     pango_matrix_rotate(&matrix, 10);
-            //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
-            //     pango_context_set_matrix(context, &matrix);
-            // }
-*/
         }
     }
 }
@@ -599,17 +589,6 @@ static void i_begin_text(DCtx *ctx, const char_t *text, const real32_t x, const 
         fdesc = (PangoFontDescription *)font_native(ctx->font);
         ctx->layout = pango_cairo_create_layout(ctx->cairo);
         pango_layout_set_font_description(ctx->layout, fdesc);
-
-        /*
-        // {
-        //     PangoMatrix matrix = PANGO_MATRIX_INIT;
-        //     PangoContext *context = pango_layout_get_context(ctx->layout);
-        //     pango_matrix_rotate(&matrix, 10);
-
-        //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
-        //     pango_context_set_matrix(context, &matrix);
-        // }
-        */
     }
 
     pango_layout_set_text(ctx->layout, (const char *)text, -1);
@@ -804,17 +783,6 @@ void draw_text_extents(DCtx *ctx, const char_t *text, const real32_t refwidth, r
         fdesc = (PangoFontDescription *)font_native(ctx->font);
         ctx->layout = pango_cairo_create_layout(ctx->cairo);
         pango_layout_set_font_description(ctx->layout, fdesc);
-
-        /*
-        // {
-        //     PangoMatrix matrix = PANGO_MATRIX_INIT;
-        //     PangoContext *context = pango_layout_get_context(ctx->layout);
-        //     pango_matrix_rotate(&matrix, 10);
-
-        //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
-        //     pango_context_set_matrix(context, &matrix);
-        // }
-        */
     }
 
     pango_layout_set_text(ctx->layout, (const char *)text, -1);

--- a/contrib/gtnap/src/draw2d/gtk/osfont.c
+++ b/contrib/gtnap/src/draw2d/gtk/osfont.c
@@ -19,9 +19,6 @@
 #include <core/strings.h>
 #include <sewer/cassert.h>
 #include <sewer/ptr.h>
-#if defined(__ASSERTS__)
-#include <sewer/bmath.h>
-#endif
 
 #if !defined(__GTK3__)
 #error This file is only for GTK Toolkit

--- a/contrib/gtnap/src/draw2d/gtk/osfont.c
+++ b/contrib/gtnap/src/draw2d/gtk/osfont.c
@@ -119,7 +119,7 @@ static gint i_font_size(const real32_t size, const uint32_t style)
 
 static const char_t *i_monospace_font_family(void)
 {
-    const char_t *desired_fonts[] = {"DejaVu Sans Mono", "Ubuntu Mono", "Courier New"};
+    const char_t *desired_fonts[] = {"Ubuntu Mono", "DejaVu Sans Mono", "Courier New"};
     return draw2d_monospace_family(desired_fonts, sizeof(desired_fonts) / sizeof(const char_t *));
 }
 

--- a/contrib/gtnap/src/draw2d/gtk/osfont.c
+++ b/contrib/gtnap/src/draw2d/gtk/osfont.c
@@ -122,11 +122,12 @@ static const char_t *i_monospace_font_family(void)
 
 /*---------------------------------------------------------------------------*/
 
-OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t style)
+OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t width, const uint32_t style)
 {
     const char_t *name = NULL;
     gint psize = 0;
     PangoFontDescription *font = NULL;
+    unref(width);
 
     if (str_equ_c(family, "__SYSTEM__") == TRUE)
     {
@@ -148,6 +149,7 @@ OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t 
     pango_font_description_set_size(font, psize);
     pango_font_description_set_style(font, (style & ekFITALIC) == ekFITALIC ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
     pango_font_description_set_weight(font, (style & ekFBOLD) == ekFBOLD ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
+    pango_font_description_set_stretch(font, PANGO_STRETCH_EXTRA_EXPANDED);
     heap_auditor_add("PangoFontDescription");
     return cast(font, OSFont);
 }
@@ -176,6 +178,15 @@ void osfont_extents(const OSFont *font, const char_t *text, const real32_t refwi
     }
 
     pango_layout_set_font_description(i_LAYOUT, cast(font, PangoFontDescription));
+        // {
+        //     PangoMatrix matrix = PANGO_MATRIX_INIT;
+        //     PangoContext *context = pango_layout_get_context(i_LAYOUT);
+        //     pango_matrix_rotate(&matrix, 10);
+
+        //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
+        //     pango_context_set_matrix(context, &matrix);
+        // }
+
     pango_layout_set_text(i_LAYOUT, (const char *)text, -1);
     pango_layout_set_width(i_LAYOUT, refwidth < 0 ? -1 : (int)(refwidth * PANGO_SCALE));
     pango_layout_get_pixel_size(i_LAYOUT, &w, &h);

--- a/contrib/gtnap/src/draw2d/gtk/osfont.c
+++ b/contrib/gtnap/src/draw2d/gtk/osfont.c
@@ -125,33 +125,14 @@ static const char_t *i_monospace_font_family(void)
 
 /*---------------------------------------------------------------------------*/
 
-/*
-static gint i_scale_size_to_cell(const real32_t size, const uint32_t style, PangoFontDescription *font)
+static gint i_scale_size_to_cell(const real32_t size, const int pango_size, PangoFontDescription *font)
 {
-    real32_t cursize = size;
     real32_t cell_size = 1e8f;
     gint new_pango_size = 0;
-    while (cell_size > size)
-    {
-        cursize -= 1;
-        new_pango_size = i_font_size(cursize, style);
-        pango_font_description_set_size(font, new_pango_size);
-        pango_font_description_set_style(font, (style & ekFITALIC) == ekFITALIC ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
-        pango_font_description_set_weight(font, (style & ekFBOLD) == ekFBOLD ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
-        osfont_extents(cast_const(font, OSFont), "REFTEXT", -1, NULL, &cell_size);
-    }
-
+    osfont_extents(cast(font, OSFont), "REFTEXT", -1, NULL, &cell_size);
+    new_pango_size = (gint)((size * (real32_t)pango_size) / cell_size);
     return new_pango_size;
-    // new_pango_size = (gint)((cell_size * (real32_t)pango_size) / cur_cell_size);
-    // cassert(new_pango_size < pango_size);
-    // pango_font_description_set_size(font, new_pango_size);
-
-    // #if defined(__ASSERTS__)
-    //     osfont_extents(cast_const(font, OSFont), "REFTEXT", -1, NULL, &cur_cell_size);
-    //     cassert(bmath_absf(cur_cell_size - cell_size) < 1.f);
-    // #endif
 }
-*/
 
 /*---------------------------------------------------------------------------*/
 
@@ -183,18 +164,11 @@ OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t 
     pango_font_description_set_style(font, (style & ekFITALIC) == ekFITALIC ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
     pango_font_description_set_weight(font, (style & ekFBOLD) == ekFBOLD ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
 
-    /*
     if ((style & ekFCELL) == ekFCELL)
     {
-        gint s = i_scale_size_to_cell(size, style, font);
-        pango_font_description_free(font);
-        font = pango_font_description_new();
-        pango_font_description_set_family(font, name);
+        gint s = i_scale_size_to_cell(size, psize, font);
         pango_font_description_set_size(font, s);
-        pango_font_description_set_style(font, (style & ekFITALIC) == ekFITALIC ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
-        pango_font_description_set_weight(font, (style & ekFBOLD) == ekFBOLD ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
     }
-*/
 
     heap_auditor_add("PangoFontDescription");
     return cast(font, OSFont);
@@ -224,18 +198,6 @@ void osfont_extents(const OSFont *font, const char_t *text, const real32_t refwi
     }
 
     pango_layout_set_font_description(i_LAYOUT, cast(font, PangoFontDescription));
-
-    /*
-    // {
-    //     PangoMatrix matrix = PANGO_MATRIX_INIT;
-    //     PangoContext *context = pango_layout_get_context(i_LAYOUT);
-    //     pango_matrix_rotate(&matrix, 10);
-
-    //     //pango_matrix_scale(&matrix, 0.8, 1.0);  // Escalar solo en ancho
-    //     pango_context_set_matrix(context, &matrix);
-    // }
-*/
-
     pango_layout_set_text(i_LAYOUT, (const char *)text, -1);
     pango_layout_set_width(i_LAYOUT, refwidth < 0 ? -1 : (int)(refwidth * PANGO_SCALE));
     pango_layout_get_pixel_size(i_LAYOUT, &w, &h);

--- a/contrib/gtnap/src/draw2d/osx/osfont.m
+++ b/contrib/gtnap/src/draw2d/osx/osfont.m
@@ -86,21 +86,42 @@ static const char_t *i_monospace_font_family(void)
 }
 
 /*---------------------------------------------------------------------------*/
-
-static NSFont *i_convent_to_italic(NSFont *font, const CGFloat height, NSFontManager *font_manager)
+/*
+ * This funtion apply two transforms:
+ *  - A shear if itatic is required.
+ *  - A x-scale if we need a char width different that font defaults.
+ */
+static NSFont *i_font_transform(NSFont *font, const CGFloat scale_x, const CGFloat height, const BOOL italic, NSFontManager *font_manager)
 {
-    NSFont *italic_font = nil;
-    NSFontTraitMask fontTraits = (NSFontTraitMask)0;
+    NSFont *tfont = nil;
+    BOOL with_italic = NO;
     cassert_no_null(font);
 
-    italic_font = [font_manager convertFont:font toHaveTrait:NSItalicFontMask];
-    fontTraits = [font_manager traitsOfFont:italic_font];
-
-    if ((fontTraits & NSItalicFontMask) == 0)
+    if (italic == YES)
+    {
+        /* The NSFontManager can apply the italic without affine */
+        NSFontTraitMask traits = 0;
+        tfont = [font_manager convertFont:font toHaveTrait:NSItalicFontMask];
+        traits = [font_manager traitsOfFont:tfont];
+        if ((traits & NSItalicFontMask) == NSItalicFontMask)
+            with_italic = YES;
+    }
+    else
+    {
+        tfont = font;
+    }
+    
+    /* We have to apply an affine transform to text */
+    if ((italic == YES && with_italic == NO)
+        || fabs((double)scale_x - 1) > 0.01)
     {
         NSAffineTransform *font_transform = [NSAffineTransform transform];
-        [font_transform scaleBy:height];
+        
+        /* Apply the x-scale */
+        [font_transform scaleXBy:scale_x * height yBy:height];
 
+        /* Italic is required, but don't apply by FontManager */
+        if (italic == YES && with_italic == NO)
         {
             NSAffineTransformStruct data;
             NSAffineTransform *italic_transform = nil;
@@ -115,20 +136,33 @@ static NSFont *i_convent_to_italic(NSFont *font, const CGFloat height, NSFontMan
             [font_transform appendTransform:italic_transform];
         }
 
-        italic_font = [NSFont fontWithDescriptor:[italic_font fontDescriptor] textTransform:font_transform];
+        tfont = [NSFont fontWithDescriptor:[tfont fontDescriptor] textTransform:font_transform];
     }
 
-    return italic_font;
+    return tfont;
 }
 
 /*---------------------------------------------------------------------------*/
 
-OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t style)
+static real32_t i_width_scale(NSFont *font, const real32_t width)
+{
+    const char_t *reftext = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    real32_t twidth = 0, theight = 0;
+    osfont_extents(cast(font, OSFont), reftext, -1, &twidth, &theight);
+    twidth /= str_len_c(reftext);
+    unref(theight);
+    return width / twidth;
+}
+
+/*---------------------------------------------------------------------------*/
+
+OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t width, const uint32_t style)
 {
     const char_t *name = NULL;
     NSFont *nsfont = nil;
     cassert(size > 0.f);
-
+    unref(width);
+    
     if (str_equ_c(family, "__SYSTEM__") == TRUE)
     {
         if (style & ekFBOLD)
@@ -165,10 +199,15 @@ OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t 
 
     if (nsfont != nil)
     {
-        if (style & ekFITALIC)
+        BOOL with_italic = (style & ekFITALIC) == ekFITALIC;
+        real32_t scale_x = 1.f;
+        if (width > 0)
+            scale_x = i_width_scale(nsfont, width);
+
+        if (with_italic || fabsf(scale_x - 1) > 0.01)
         {
-            NSFontManager *fontManager = [NSFontManager sharedFontManager];
-            nsfont = i_convent_to_italic(nsfont, (CGFloat)size, fontManager);
+            NSFontManager *manager = [NSFontManager sharedFontManager];
+            nsfont = i_font_transform(nsfont, (CGFloat)scale_x, (CGFloat)size, with_italic, manager);
         }
 
         [nsfont retain];

--- a/contrib/gtnap/src/draw2d/win/osfont.cpp
+++ b/contrib/gtnap/src/draw2d/win/osfont.cpp
@@ -124,20 +124,21 @@ real32_t font_mini_size(void)
 
 static int i_font_height(const real32_t size, const uint32_t style)
 {
+    int height = 0;
     if ((style & ekFPOINTS) == ekFPOINTS)
     {
-        return -(int)((size * (real32_t)kLOG_PIXY) / 72.f);
+        height = -(int)((size * (real32_t)kLOG_PIXY) / 72.f);
     }
-    /* else if ((style & ekFCELL) == ekFCELL)
-    {
-         return (int)size;
-    }
-    */
     else
     {
         cassert((style & ekFPIXELS) == ekFPIXELS);
-        return -(int)size;
+        height = -(int)size;
     }
+
+    if ((style & ekFCELL) == ekFCELL)
+        height = -height;
+
+    return height;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -198,7 +199,7 @@ OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t 
     nHeight = i_font_height(size, style);
 
     hfont = CreateFont(
-        - nHeight,
+        nHeight,
         PARAM(nWidth, width >= 0 ? (int)width : 0),
         PARAM(nEscapement, 0),
         PARAM(nOrientation, 0),

--- a/contrib/gtnap/src/draw2d/win/osfont.cpp
+++ b/contrib/gtnap/src/draw2d/win/osfont.cpp
@@ -166,7 +166,7 @@ static const char_t *i_monospace_font_family(void)
 
 /*---------------------------------------------------------------------------*/
 
-OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t style)
+OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t width, const uint32_t style)
 {
     const char_t *face_name = NULL;
     WCHAR face_namew[LF_FULLFACESIZE];
@@ -199,7 +199,7 @@ OSFont *osfont_create(const char_t *family, const real32_t size, const uint32_t 
 
     hfont = CreateFont(
         nHeight,
-        PARAM(nWidth, 0),
+        PARAM(nWidth, width >= 0 ? (int)width : 0),
         PARAM(nEscapement, 0),
         PARAM(nOrientation, 0),
         (style & ekFBOLD) == ekFBOLD ? FW_BOLD : FW_MEDIUM,

--- a/contrib/gtnap/src/draw2d/win/osfont.cpp
+++ b/contrib/gtnap/src/draw2d/win/osfont.cpp
@@ -198,7 +198,7 @@ OSFont *osfont_create(const char_t *family, const real32_t size, const real32_t 
     nHeight = i_font_height(size, style);
 
     hfont = CreateFont(
-        nHeight,
+        - nHeight,
         PARAM(nWidth, width >= 0 ? (int)width : 0),
         PARAM(nEscapement, 0),
         PARAM(nOrientation, 0),

--- a/contrib/gtnap/src/gtnap/gtnap.c
+++ b/contrib/gtnap/src/gtnap/gtnap.c
@@ -924,7 +924,7 @@ static void i_compute_font_size(const real32_t screen_width, const real32_t scre
      * Usar os valores máximos para ir reduzindo o tamanho até que
      * caiba na resolução da tela (a maior tela até agora foi a 1024 x 1860)
      */
-    N_HeightMax = 24.f + 1.f; /* em teste real, só coube 23 */
+    N_HeightMax = 23.f + 1.f; /* em teste real, só coube 23 */
     N_WidthMax = 15.f + 1.f;  /* em teste real, só coube 15 */
 
     /*
@@ -954,7 +954,10 @@ static void i_compute_font_size(const real32_t screen_width, const real32_t scre
             break;
         }
     }
-
+    
+    if (N_HeightTemp < N_HeightMax)
+        N_HeightMax = N_HeightTemp;
+    
     /*
      * Setar a maior largura de fonte possível, que ainda caiba 110 colunas.
      * Se WVW_MAXMAXCOL() continuar com o mesmo valor, é porque não coube

--- a/contrib/gtnap/src/gtnap/gtnap.c
+++ b/contrib/gtnap/src/gtnap/gtnap.c
@@ -951,7 +951,7 @@ static GtNap *i_gtnap_create(void)
     GTNAP_GLOBAL->date_chars = GTNAP_GLOBAL->date_digits + 2;
 
 #if defined (__WINDOWS__)
-    draw2d_user_monospace_family("Courier New");
+    font_preferred_monospace("Courier New");
 #endif
 
     {

--- a/contrib/gtnap/src/gtnap/gtnap.c
+++ b/contrib/gtnap/src/gtnap/gtnap.c
@@ -924,7 +924,7 @@ static void i_compute_font_size(const real32_t screen_width, const real32_t scre
      * Usar os valores máximos para ir reduzindo o tamanho até que
      * caiba na resolução da tela (a maior tela até agora foi a 1024 x 1860)
      */
-    N_HeightMax = 23.f + 1.f; /* em teste real, só coube 23 */
+    N_HeightMax = 24.f + 1.f; /* em teste real, só coube 23 */
     N_WidthMax = 15.f + 1.f;  /* em teste real, só coube 15 */
 
     /*

--- a/contrib/gtnap/src/gtnap/gtnap.c
+++ b/contrib/gtnap/src/gtnap/gtnap.c
@@ -924,8 +924,8 @@ static void i_compute_font_size(const real32_t screen_width, const real32_t scre
      * Usar os valores máximos para ir reduzindo o tamanho até que
      * caiba na resolução da tela (a maior tela até agora foi a 1024 x 1860)
      */
-    N_HeightMax = 24.f + 1.f; // em teste real, só coube 23
-    N_WidthMax = 15.f + 1.f;  // em teste real, só coube 15
+    N_HeightMax = 24.f + 1.f; /* em teste real, só coube 23 */
+    N_WidthMax = 15.f + 1.f;  /* em teste real, só coube 15 */
 
     /*
      * Setar a maior altura de fonte possível, que ainda caiba 35 linhas.

--- a/contrib/gtnap/src/gtnap/gtnap.c
+++ b/contrib/gtnap/src/gtnap/gtnap.c
@@ -172,7 +172,8 @@ struct _gtnap_modal_t
 struct _gtnap_t
 {
     Font *global_font;
-    Font *reduced_font;
+    Font *button_font;
+    Font *edit_font;
     uint8_t date_digits;
     uint8_t date_chars;
     String *title;
@@ -296,6 +297,8 @@ static const bool_t i_FULL_HBFUNCS = FALSE;
 
 /* Harbour colors sensible to light/dark themes */
 static color_t i_COLORS[16];
+
+static const real32_t i_FONT_SIZE_DIFF = 0.7f;
 
 /*---------------------------------------------------------------------------*/
 
@@ -523,7 +526,8 @@ static void i_gtnap_destroy(GtNap **gtnap)
     cassert(*gtnap == GTNAP_GLOBAL);
     arrpt_destroy(&(*gtnap)->windows, i_destroy_gtwin, GtNapWindow);
     font_destroy(&(*gtnap)->global_font);
-    font_destroy(&(*gtnap)->reduced_font);
+    font_destroy(&(*gtnap)->button_font);
+    font_destroy(&(*gtnap)->edit_font);
     str_destroy(&(*gtnap)->title);
     str_destroy(&(*gtnap)->working_path);
     str_destroy(&(*gtnap)->debugger_path);
@@ -608,10 +612,11 @@ static GtNapWindow *i_current_gtwin(GtNap *gtnap)
 static GtNapWindow *i_current_main_gtwin(GtNap *gtnap)
 {
     cassert_no_null(gtnap);
-    arrpt_forback(gtwin, gtnap->windows, GtNapWindow) if (gtwin->parent_id == UINT32_MAX) return gtwin;
-arrpt_end
-();
-return NULL;
+    arrpt_forback(gtwin, gtnap->windows, GtNapWindow)
+        if (gtwin->parent_id == UINT32_MAX)
+            return gtwin;
+    arrpt_end()
+    return NULL;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -718,33 +723,6 @@ static Listener *i_gtnap_listener(HB_ITEM *block, const int32_t key, const uint3
 
 /*---------------------------------------------------------------------------*/
 
-static void i_create_fonts(const real32_t size, GtNap *gtnap)
-{
-    real32_t rsize = bmath_ceilf(size * .9f);
-    cassert_no_null(gtnap);
-    ptr_destopt(font_destroy, &gtnap->global_font, Font);
-    ptr_destopt(font_destroy, &gtnap->reduced_font, Font);
-    gtnap->global_font = font_monospace(size, 0);
-    gtnap->reduced_font = font_monospace(rsize, 0);
-}
-
-/*---------------------------------------------------------------------------*/
-
-static void i_create_fonts2(const real32_t size, const real32_t width, GtNap *gtnap)
-{
-    real32_t rsize = bmath_ceilf(size * .8f);
-    real32_t rwidth = bmath_ceilf(width * .8f);
-    cassert_no_null(gtnap);
-    ptr_destopt(font_destroy, &gtnap->global_font, Font);
-    ptr_destopt(font_destroy, &gtnap->reduced_font, Font);
-    gtnap->global_font = font_monospace(size, ekFCELL);
-    gtnap->reduced_font = font_monospace(rsize, ekFCELL);
-    font_set_width(gtnap->global_font, width);
-    font_set_width(gtnap->reduced_font, rwidth);
-}
-
-/*---------------------------------------------------------------------------*/
-
 /* Change this value to make buttons higher */
 static real32_t i_button_vpadding(void)
 {
@@ -761,35 +739,61 @@ static real32_t i_edit_vpadding(void)
 
 /*---------------------------------------------------------------------------*/
 
-static void i_compute_cell_size(GtNap *gtnap)
+static real32_t i_button_size(const Font *font)
 {
-    real32_t bh = 0, eh = 0;
+    /* Create an impostor window, only for measure the real height of buttons */
+    real32_t bh = 0;
+    Panel *panel = panel_create();
+    Button *button = button_push();
+    Window *window = window_create(ekWINDOW_STD | ekWINDOW_OFFSCREEN);
+    Layout *layout = layout_create(1, 1);
+    button_text(button, "DEMO");
+    button_font(button, font);
+    button_vpadding(button, i_button_vpadding());
+    layout_button(layout, button, 0, 0);
+    panel_layout(panel, layout);
+    window_panel(window, panel);
+    window_show(window);
+    bh = button_get_height(button);
+    window_destroy(&window);
+    return bh;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static real32_t i_edit_size(const Font *font)
+{
+    /* Create an impostor window, only for measure the real height of editbox */
+    real32_t eh = 0;
+    Panel *panel = panel_create();
+    Edit *edit = edit_create();
+    Window *window = window_create(ekWINDOW_STD | ekWINDOW_OFFSCREEN);
+    Layout *layout = layout_create(1, 1);
+    edit_font(edit, font);
+    edit_vpadding(edit, i_edit_vpadding());
+    layout_edit(layout, edit, 0, 0);
+    panel_layout(panel, layout);
+    window_panel(window, panel);
+    window_show(window);
+    eh = edit_get_height(edit);
+    window_destroy(&window);
+    return eh;
+}
+
+/*---------------------------------------------------------------------------*/
+
+static void i_compute_cell_size(GtNap *gtnap, const real32_t size, const real32_t width)
+{
     real32_t fw = 0, fh = 0;
+    real32_t bs = 0, es = 0;
+    real32_t bh = 0, eh = 0;
 
     cassert_no_null(gtnap);
+    ptr_destopt(font_destroy, &gtnap->global_font, Font);
+    gtnap->global_font = font_monospace(size, ekFCELL);
+    font_set_width(gtnap->global_font, width);
 
-    /* Create an impostor window, only for measure the real height of buttons and edits */
-    {
-        Panel *panel = panel_create();
-        Button *button = button_push();
-        Edit *edit = edit_create();
-        Window *window = window_create(ekWINDOW_STD | ekWINDOW_OFFSCREEN);
-        Layout *layout = layout_create(1, 2);
-        button_text(button, "DEMO");
-        button_font(button, gtnap->reduced_font);
-        button_vpadding(button, i_button_vpadding());
-        edit_font(edit, gtnap->reduced_font);
-        edit_vpadding(edit, i_edit_vpadding());
-        layout_button(layout, button, 0, 0);
-        layout_edit(layout, edit, 0, 1);
-        panel_layout(panel, layout);
-        window_panel(window, panel);
-        window_show(window);
-        bh = button_get_height(button);
-        eh = edit_get_height(edit);
-        window_destroy(&window);
-    }
-
+    /* Compute the real size of a cell, based on font */
     {
         real32_t w, h;
         const char_t *reftext = "exibicao/edicao de texto em memoria";
@@ -798,62 +802,57 @@ static void i_compute_cell_size(GtNap *gtnap)
         fh = h;
     }
 
-    gtnap->cell_x_sizef = fw;
+    /*
+     * We need to set a font size for buttons, where the button
+     * height doesn't exceed the cell height
+     */
+    bs = size;
+    bh = 1e8f;
+    while (bh - fh > i_FONT_SIZE_DIFF)
+    {
+        bs -= 1;
+        ptr_destopt(font_destroy, &gtnap->button_font, Font);
+        gtnap->button_font = font_monospace(bs, ekFCELL);
+        bh = i_button_size(gtnap->button_font);
+    }
 
-    /* Cell height will be the higher of labels, buttons and edits */
+    /*
+     * We need to set a font size for edits, where the edit
+     * height doesn't exceed the cell height
+     */
+    es = size;
+    eh = 1e8f;
+    while (eh - fh > i_FONT_SIZE_DIFF)
+    {
+        es -= 1;
+        ptr_destopt(font_destroy, &gtnap->edit_font, Font);
+        gtnap->edit_font = font_monospace(es, ekFCELL);
+        eh = i_edit_size(gtnap->edit_font);
+    }
+
+    /* Final cell sizes */
+    gtnap->cell_x_sizef = fw;
     gtnap->cell_y_sizef = fh;
     gtnap->label_y_sizef = fh;
     gtnap->button_y_sizef = bh;
     gtnap->edit_y_sizef = eh;
-
-    if (bh > gtnap->cell_y_sizef)
-        gtnap->cell_y_sizef = bh;
-
-    if (eh > gtnap->cell_y_sizef)
-        gtnap->cell_y_sizef = eh;
+    cassert(gtnap->label_y_sizef <= gtnap->cell_y_sizef);
+    cassert(gtnap->button_y_sizef <= gtnap->cell_y_sizef);
+    cassert(gtnap->edit_y_sizef <= gtnap->cell_y_sizef);
 }
 
 /*---------------------------------------------------------------------------*/
 
-static void i_compute_font_size(const real32_t max_width, const real32_t max_height, GtNap *gtnap)
-{
-    real32_t font_size = max_height / (real32_t)(gtnap->rows + 5);
-
-    for (;;)
-    {
-        i_create_fonts(font_size, gtnap);
-        i_compute_cell_size(gtnap);
-
-        /* The total width exceeds the screen limits */
-        if (gtnap->cell_x_sizef * gtnap->cols > max_width)
-        {
-            font_size -= 1;
-            continue;
-        }
-
-        /* The total height exceeds the screen limits */
-        if (gtnap->cell_y_sizef * gtnap->rows > max_height)
-        {
-            font_size -= 1;
-            continue;
-        }
-
-        break;
-    }
-}
-
-/*---------------------------------------------------------------------------*/
-
-/* 
+/*
  * This function to select the font size has been cloned from original
  * 'cuademo::outros.prg', working under GTWVW.
  */
-static void i_compute_font_size2(const real32_t screen_width, const real32_t screen_height, GtNap *gtnap)
+static void i_compute_font_size(const real32_t screen_width, const real32_t screen_height, GtNap *gtnap)
 {
-    real32_t N_HeightMin = 0;   /* altura  mínima que, com certeza, cabe na menor resolução */
-    real32_t N_WidthMin = 0;    /* largura mínima que, com certeza, cabe na menor resolução */
-    real32_t N_HeightMax = 0;   /* altura  máxima que ultrapassa a maior resolução */
-    real32_t N_WidthMax = 0;    /* largura máxima que ultrapassa a maior resolução */
+    real32_t N_HeightMin = 0; /* altura  mínima que, com certeza, cabe na menor resolução */
+    real32_t N_WidthMin = 0;  /* largura mínima que, com certeza, cabe na menor resolução */
+    real32_t N_HeightMax = 0; /* altura  máxima que ultrapassa a maior resolução */
+    real32_t N_WidthMax = 0;  /* largura máxima que ultrapassa a maior resolução */
     real32_t N_HeightTemp = 0;
     real32_t N_WidthTemp = 0;
     const char_t *C_Fonte = NULL;
@@ -861,14 +860,14 @@ static void i_compute_font_size2(const real32_t screen_width, const real32_t scr
     /*
      * Resoluções mais comuns:
      * N_ScreenHeight   N_ScreenWidth
-     *    >= 1024         >= 1680    
-     *    >= 1024         >= 1440    
-     *    >= 1024         >= 1280    
-     *    >=  960         >= 1280    
-     *    >=  864         >= 1152    
-     *    >=  768         >= 1024   
+     *    >= 1024         >= 1680
+     *    >= 1024         >= 1440
+     *    >= 1024         >= 1280
+     *    >=  960         >= 1280
+     *    >=  864         >= 1152
+     *    >=  768         >= 1024
      *    >=  600         >= 1024   (NetBooks)
-     *    >=  600         >=  800   (SuperVGA) 
+     *    >=  600         >=  800   (SuperVGA)
      *
      */
     if (screen_height <= 600)
@@ -879,14 +878,14 @@ static void i_compute_font_size2(const real32_t screen_width, const real32_t scr
          * difícil. Nesta situação, o "Lucida Console" tem aparência bem melhor.
          */
 
-        /* 
-         * Lucida Console não está presente no Linux ou macOS. Nestes casos, 
+        /*
+         * Lucida Console não está presente no Linux ou macOS. Nestes casos,
          * deixamos a fonte monoespaçada como padrão.
          */
-#if defined (__WINDOWS__)
-         C_Fonte = "Lucida Console";
-#else 
-         C_Fonte = NULL;
+#if defined(__WINDOWS__)
+        C_Fonte = "Lucida Console";
+#else
+        C_Fonte = NULL;
 #endif
     }
     else
@@ -898,12 +897,12 @@ static void i_compute_font_size2(const real32_t screen_width, const real32_t scr
          * com aparência pesada e feia.
          */
 
-        /* 
+        /*
          * "Courier New" está presente em praticamente todos os sistemas, incluindo
-         * Linux e macOS. Se não estiver presente, a fonte monoespaçada padrão será 
+         * Linux e macOS. Se não estiver presente, a fonte monoespaçada padrão será
          * selecionada.
          */
-         C_Fonte = "Courier New";
+        C_Fonte = "Courier New";
     }
 
     if (C_Fonte != NULL)
@@ -919,192 +918,70 @@ static void i_compute_font_size2(const real32_t screen_width, const real32_t scr
      * linhas para 35 e colunas para 110, até mesmo na resolução 600 X 800
      */
     N_HeightMin = 6.f;
-    N_WidthMin  = 5.f;
-
-      //*
-      //Wvw_SetFont(,C_Fonte,N_HeightMin,N_WidthMin)
-      //Wvw_PBSetFont(,C_Fonte,N_HeightMin,N_WidthMin)
-      //WVW_SetDefLineSpacing( 4 )  // todo o sistema (novas janelas)
-      //WVW_SetLineSpacing( 0, 4 )  // tela "default" do GTWVW
-      //SetMode(N_QtLin,N_QtCol)
-      //IF L_Verbose
-      //   ALERT("Com height mínimo "+LTRIM(STR(N_HeightMin))+" e width mínimo "+;
-      //         LTRIM(STR(N_WidthMin))+;
-      //         " cabem "+LTRIM(STR(WVW_MAXMAXROW())) +" rows e "+;
-      //         LTRIM(STR(WVW_MAXMAXCOL()))+" cols")
-      //ENDIF                 
-      //ASSUME MAXROW() == N_QtLin-1
-      //ASSUME MAXCOL() == N_QtCol-1
-      //IF L_Verbose
-      //   ALERT("Tela mudada para "+LTRIM(STR(N_QtLin))+" linhas "+;
-      //         LTRIM(STR(N_QtCol))+" colunas")
-      //ENDIF
+    N_WidthMin = 5.f;
 
     /*
-     * Usar os valores máximos para ir reduzindo o tamanho até que 
+     * Usar os valores máximos para ir reduzindo o tamanho até que
      * caiba na resolução da tela (a maior tela até agora foi a 1024 x 1860)
      */
-    N_HeightMax = 24.f + 1.f;    // em teste real, só coube 23
-    N_WidthMax  = 15.f + 1.f;    // em teste real, só coube 15
+    N_HeightMax = 24.f + 1.f; // em teste real, só coube 23
+    N_WidthMax = 15.f + 1.f;  // em teste real, só coube 15
 
     /*
      * Setar a maior altura de fonte possível, que ainda caiba 35 linhas.
      * Se WVW_MAXMAXROW() continuar com o mesmo valor, é porque não coube
      * na tela, sendo necessário reduzir ainda mais a altura do fonte.
      */
-    i_create_fonts2(N_HeightMax, -1, gtnap);
-    i_compute_cell_size(gtnap);
+    i_compute_cell_size(gtnap, N_HeightMax, -1);
     N_HeightTemp = N_HeightMax;
     for (;;)
     {
         /* The font computed by the system has not the desired height */
-        if (gtnap->cell_y_sizef - N_HeightMax > 0.7f)
+        if (gtnap->cell_y_sizef - N_HeightMax > i_FONT_SIZE_DIFF)
         {
             N_HeightTemp -= 1;
-            i_create_fonts2(N_HeightTemp, -1, gtnap);
-            i_compute_cell_size(gtnap);
+            i_compute_cell_size(gtnap, N_HeightTemp, -1);
         }
         /* The total height exceeds the screen limits */
-        else if (gtnap->cell_y_sizef * gtnap->rows > screen_height 
-            && N_HeightMax > N_HeightMin)
+        else if (gtnap->cell_y_sizef * gtnap->rows > screen_height && N_HeightMax > N_HeightMin)
         {
             N_HeightMax -= 1.f;
             N_HeightTemp -= N_HeightMax;
-            i_create_fonts2(N_HeightMax, -1, gtnap);
-            i_compute_cell_size(gtnap);
+            i_compute_cell_size(gtnap, N_HeightMax, -1);
         }
         else
         {
             break;
         }
     }
-
-      //N_MaxMaxRow := WVW_MAXMAXROW()
-      //Wvw_SetFont(,C_Fonte,N_HeightMax)
-      //Wvw_PBSetFont(,C_Fonte,N_HeightMax)
-      //IF L_Verbose
-      //   ALERT("Com height "+LTRIM(STR(N_HeightMax))+;
-      //         " cabe "+LTRIM(STR(WVW_MAXMAXROW()))+" rows" )
-      //ENDIF                 
-      //DO WHILE WVW_MAXMAXROW() == N_MaxMaxRow .AND. ;
-      //         N_HeightMax > N_HeightMin
-      //   N_HeightMax--
-      //   Wvw_SetFont(,C_Fonte,N_HeightMax)
-      //   Wvw_PBSetFont(,C_Fonte,N_HeightMax)
-      //   IF L_Verbose
-      //      ALERT("Com height "+LTRIM(STR(N_HeightMax))+;
-      //            " cabe "+LTRIM(STR(WVW_MAXMAXROW()))+" rows" )
-      //   ENDIF                 
-      //ENDDO
-      //IF L_Verbose
-      //   ALERT("O height final foi "+LTRIM(STR(N_HeightMax)))
-      //ENDIF   
 
     /*
      * Setar a maior largura de fonte possível, que ainda caiba 110 colunas.
      * Se WVW_MAXMAXCOL() continuar com o mesmo valor, é porque não coube
      * na tela, sendo necessário reduzir ainda mais a largura do fonte.
      */
-    i_create_fonts2(N_HeightMax, N_WidthMax, gtnap);
-    i_compute_cell_size(gtnap);
+    i_compute_cell_size(gtnap, N_HeightMax, N_WidthMax);
     N_WidthTemp = N_WidthMax;
-
     for (;;)
     {
-
         /* The font computed by the system has not the desired width */
-        if (gtnap->cell_x_sizef - N_WidthMax > 0.7f)
+        if (gtnap->cell_x_sizef - N_WidthMax > i_FONT_SIZE_DIFF)
         {
             N_WidthTemp -= 1;
-            i_create_fonts2(N_HeightMax, N_WidthTemp, gtnap);
-            i_compute_cell_size(gtnap);
+            i_compute_cell_size(gtnap, N_HeightMax, N_WidthTemp);
         }
         /* The total width exceeds the screen limits */
-        else if (gtnap->cell_x_sizef * gtnap->cols > screen_width
-            && N_WidthMax > N_WidthMin)
+        else if (gtnap->cell_x_sizef * gtnap->cols > screen_width && N_WidthMax > N_WidthMin)
         {
             N_WidthMax -= 1.f;
             N_WidthTemp = N_WidthMax;
-            i_create_fonts2(N_HeightMax, N_WidthMax, gtnap);
-            i_compute_cell_size(gtnap);
+            i_compute_cell_size(gtnap, N_HeightMax, N_WidthMax);
         }
         else
         {
             break;
         }
     }
-   //   N_MaxMaxCol := WVW_MAXMAXCOL()
-   //   Wvw_SetFont(,C_Fonte,N_HeightMax,N_WidthMax)
-   //   Wvw_PBSetFont(,C_Fonte,N_HeightMax,N_WidthMax)
-   //   IF L_Verbose
-   //      ALERT("Com width "+LTRIM(STR(N_WidthMax))+;
-   //            " cabe "+LTRIM(STR(WVW_MAXMAXCOL()))+" cols" )
-   //   ENDIF                 
-   //   DO WHILE WVW_MAXMAXCOL() == N_MaxMaxCol .AND. ;
-   //            N_WidthMax > N_WidthMin
-   //      N_WidthMax--
-   //      Wvw_SetFont(,C_Fonte,N_HeightMax,N_WidthMax)
-   //      Wvw_PBSetFont(,C_Fonte,N_HeightMax,N_WidthMax)
-   //      IF L_Verbose
-   //         ALERT("Com width "+LTRIM(STR(N_WidthMax))+;
-   //               " cabe "+LTRIM(STR(WVW_MAXMAXCOL()))+" cols")
-   //      ENDIF                 
-   //   ENDDO
-   //   IF L_Verbose
-   //      ALERT("O width final foi "+LTRIM(STR(N_WidthMax)))
-   //   ENDIF   
-   //   ASSUME WVW_MAXMAXROW() >= N_QtLin-1
-   //   ASSUME WVW_MAXMAXCOL() >= N_QtCol-1
-   //   *
-   //   /*
-   //   * USAR ESTE TRECHO DE CÓDIGO SÓ EM AMBIENTE DE TESTE E NO CASO DE
-   //   * MUDANÇA DE FONTE, OU MUDANÇA DE TAMANHO MÍNIMO DE RESULUÇÃO.
-   //   #INCLUDE "intercep.ch"
-   //   *
-   //   DBCREATE_T(ASPECTMP()+"testfont.dbf",;
-   //              {{"HEIGHT"   ,"N", 3,0},;
-   //               {"WIDTH"    ,"N", 3,0},;
-   //               {"HEIGHT_OK","L", 1,0},;
-   //               {"WIDTH_OK" ,"L", 1,0},;
-   //               {"MAXMAXROW","N", 3,0},;
-   //               {"MAXMAXCOL","N", 3,0}})
-   //   *
-   //   USE_T A19276 TABLE (ASPECTMP()+"testfont.dbf") CANINSERT EXCLUSIVE FINALUSE
-   //   PRIVATE N_HEIGHT
-   //   FOR N_HEIGHT := 5 TO 35
-   //      PRIVATE N_WIDTH
-   //      PRIVATE N_MaxMaxRow_OLD := WVW_MAXMAXROW()
-   //      FOR N_WIDTH := 4 TO 25
-   //          PRIVATE N_MaxMaxCol_OLD := WVW_MAXMAXCOL()
-   //          *
-   //          Wvw_SetFont(,C_Fonte,N_HEIGHT,N_WIDTH)
-   //          WVW_SetDefLineSpacing( 4 )  // todo o sistema (novas janelas)
-   //          WVW_SetLineSpacing( 0, 4 )  // tela "default" do GTWVW
-   //          SetMode(N_QtLin,N_QtCol)
-   //          *
-   //          ASSUME MAXROW() == N_QtLin-1
-   //          ASSUME MAXCOL() == N_QtCol-1
-   //          *
-   //          TESTFONT->(APP_REG())
-   //          ALIAS TESTFONT REPL HEIGHT     WITH N_HEIGHT
-   //          ALIAS TESTFONT REPL WIDTH      WITH N_WIDTH
-   //          IF WVW_MAXMAXROW() # N_MaxMaxRow_OLD
-   //             ALIAS TESTFONT REPL HEIGHT_OK WITH .T.
-   //          ENDIF
-   //          IF WVW_MAXMAXCOL() # N_MaxMaxCol_OLD      
-   //             ALIAS TESTFONT REPL WIDTH_OK WITH .T.
-   //          ENDIF   
-   //          ALIAS TESTFONT REPL MAXMAXROW  WITH WVW_MAXMAXROW()
-   //          ALIAS TESTFONT REPL MAXMAXCOL  WITH WVW_MAXMAXCOL()
-   //          UNLOCK
-   //      NEXT
-   //   NEXT   
-   //   CLOSE TESTFONT
-   //   */
-   //   
-   //RETURN NIL
-
-
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1231,10 +1108,6 @@ static GtNap *i_gtnap_create(void)
     GTNAP_GLOBAL->date_digits = (hb_setGetCentury() == (HB_BOOL)HB_TRUE) ? 8 : 6;
     GTNAP_GLOBAL->date_chars = GTNAP_GLOBAL->date_digits + 2;
 
-//#if defined (__WINDOWS__)
-//    font_preferred_monospace("Courier New");
-//#endif
-
     {
         char_t path[512];
         bfile_dir_work(path, sizeof(path));
@@ -1259,7 +1132,7 @@ static GtNap *i_gtnap_create(void)
     }
 
     globals_resolution(&screen);
-    i_compute_font_size2(screen.width, screen.height, GTNAP_GLOBAL);
+    i_compute_font_size(screen.width, screen.height, GTNAP_GLOBAL);
     deblib_init_colors(i_COLORS);
 
     {
@@ -2611,72 +2484,72 @@ static void i_gtwin_configure(GtNap *gtnap, GtNapWindow *gtwin, GtNapWindow *mai
         cassert(gtwin == main_gtwin);
 
         /* Configure the child (embedded) windows as subpanels */
-        arrpt_forback(embgtwin, gtnap->windows, GtNapWindow) if (embgtwin->parent_id == gtwin->id)
-        {
-            V2Df pos;
-            int32_t cell_x = embgtwin->left - gtwin->left;
-            int32_t cell_y = embgtwin->top - gtwin->top;
-            pos.x = (real32_t)cell_x * GTNAP_GLOBAL->cell_x_sizef;
-            pos.y = (real32_t)cell_y * GTNAP_GLOBAL->cell_y_sizef;
-            i_gtwin_configure(gtnap, embgtwin, gtwin);
-            _panel_attach_component(gtwin->panel, (GuiComponent *)embgtwin->panel);
-            _component_set_frame((GuiComponent *)embgtwin->panel, &pos, &embgtwin->panel_size);
-            _component_visible((GuiComponent *)embgtwin->panel, TRUE);
-        }
-arrpt_end
-();
+        arrpt_forback(embgtwin, gtnap->windows, GtNapWindow)
+            if (embgtwin->parent_id == gtwin->id)
+            {
+                V2Df pos;
+                int32_t cell_x = embgtwin->left - gtwin->left;
+                int32_t cell_y = embgtwin->top - gtwin->top;
+                pos.x = (real32_t)cell_x * GTNAP_GLOBAL->cell_x_sizef;
+                pos.y = (real32_t)cell_y * GTNAP_GLOBAL->cell_y_sizef;
+                i_gtwin_configure(gtnap, embgtwin, gtwin);
+                _panel_attach_component(gtwin->panel, (GuiComponent *)embgtwin->panel);
+                _component_set_frame((GuiComponent *)embgtwin->panel, &pos, &embgtwin->panel_size);
+                _component_visible((GuiComponent *)embgtwin->panel, TRUE);
+            }
+        arrpt_end();
 
-/* At this point the main window (with embedded windows) is complete.
- * We begin the tabstop configuration */
-_window_taborder(gtwin->window, NULL);
-arrpt_foreach(component, gtwin->tabstops, GuiComponent)
-    _component_taborder(component, gtwin->window);
-arrpt_end()
-}
+        /* At this point the main window (with embedded windows) is complete.
+         * We begin the tabstop configuration */
+        _window_taborder(gtwin->window, NULL);
+        arrpt_foreach(component, gtwin->tabstops, GuiComponent)
+            _component_taborder(component, gtwin->window);
+        arrpt_end()
+    }
 
-/* Allow navigation between edit controls with arrows and return */
-if (i_num_edits(gtwin) > 0)
-{
-    /* At the moment, embedded windows with edits is not allowed */
-    GtNapObject *last_edit = NULL;
+    /* Allow navigation between edit controls with arrows and return */
+    if (i_num_edits(gtwin) > 0)
+    {
+        /* At the moment, embedded windows with edits is not allowed */
+        GtNapObject *last_edit = NULL;
 
+        arrpt_foreach(obj, gtwin->objects, GtNapObject)
+            if (obj->type == ekOBJ_EDIT)
+            {
+                edit_OnChange((Edit *)obj->component, listener(obj, i_OnEditChange, GtNapObject));
+                edit_OnFilter((Edit *)obj->component, listener(obj, i_OnEditFilter, GtNapObject));
+                edit_OnFocus((Edit *)obj->component, listener(obj, i_OnEditFocus, GtNapObject));
+                obj->is_last_edit = FALSE;
+                last_edit = obj;
+            }
+        arrpt_end();
+
+        cassert_no_null(last_edit);
+        last_edit->is_last_edit = TRUE;
+    }
+
+    /* Allow TextView listeners */
     arrpt_foreach(obj, gtwin->objects, GtNapObject)
-        if (obj->type == ekOBJ_EDIT)
+        if (obj->type == ekOBJ_TEXTVIEW)
         {
-            edit_OnChange((Edit *)obj->component, listener(obj, i_OnEditChange, GtNapObject));
-            edit_OnFilter((Edit *)obj->component, listener(obj, i_OnEditFilter, GtNapObject));
-            edit_OnFocus((Edit *)obj->component, listener(obj, i_OnEditFocus, GtNapObject));
-            obj->is_last_edit = FALSE;
-            last_edit = obj;
+            textview_OnFocus((TextView *)obj->component, listener(obj, i_OnTextFocus, GtNapObject));
+            if (obj->keyfilter_block != NULL)
+                textview_OnFilter((TextView *)obj->component, listener(obj, i_OnTextFilter, GtNapObject));
         }
     arrpt_end();
 
-    cassert_no_null(last_edit);
-    last_edit->is_last_edit = TRUE;
-}
-
-/* Allow TextView listeners */
-arrpt_foreach(obj, gtwin->objects, GtNapObject)
-    if (obj->type == ekOBJ_TEXTVIEW)
+    if (gtwin->buttons_navigation == TRUE)
     {
-        textview_OnFocus((TextView *)obj->component, listener(obj, i_OnTextFocus, GtNapObject));
-        if (obj->keyfilter_block != NULL)
-            textview_OnFilter((TextView *)obj->component, listener(obj, i_OnTextFilter, GtNapObject));
+        if (i_num_buttons(gtwin) > 1)
+        {
+            /* At the moment, embedded windows with button navigation is not allowed */
+            cassert(gtwin->window != NULL);
+            window_hotkey(gtwin->window, ekKEY_LEFT, 0, listener(gtwin, i_OnLeftButton, GtNapWindow));
+            window_hotkey(gtwin->window, ekKEY_RIGHT, 0, listener(gtwin, i_OnRightButton, GtNapWindow));
+        }
     }
-arrpt_end();
 
-if (gtwin->buttons_navigation == TRUE)
-{
-    if (i_num_buttons(gtwin) > 1)
-    {
-        /* At the moment, embedded windows with button navigation is not allowed */
-        cassert(gtwin->window != NULL);
-        window_hotkey(gtwin->window, ekKEY_LEFT, 0, listener(gtwin, i_OnLeftButton, GtNapWindow));
-        window_hotkey(gtwin->window, ekKEY_RIGHT, 0, listener(gtwin, i_OnRightButton, GtNapWindow));
-    }
-}
-
-gtwin->is_configured = TRUE;
+    gtwin->is_configured = TRUE;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -3599,7 +3472,7 @@ uint32_t hb_gtnap_button(const uint32_t wid, const int32_t top, const int32_t le
     button = button_push();
     listener = i_gtnap_listener(click_block, INT32_MAX, autoclose_id, gtwin, i_OnButtonClick);
     button_OnClick(button, listener);
-    button_font(button, GTNAP_GLOBAL->reduced_font);
+    button_font(button, GTNAP_GLOBAL->button_font);
     button_vpadding(button, i_button_vpadding());
     cassert(bottom == top);
     size.width = (real32_t)(right - left + 1) * GTNAP_GLOBAL->cell_x_sizef;
@@ -3676,7 +3549,7 @@ uint32_t hb_gtnap_edit(const uint32_t wid, const int32_t top, const int32_t left
     uint32_t id = UINT32_MAX;
     GtNapObject *obj = NULL;
     cassert_no_null(gtwin);
-    edit_font(edit, GTNAP_GLOBAL->reduced_font);
+    edit_font(edit, GTNAP_GLOBAL->edit_font);
     edit_vpadding(edit, i_edit_vpadding());
     size.width = (real32_t)(width + 1) * GTNAP_GLOBAL->cell_x_sizef;
     size.height = GTNAP_GLOBAL->edit_y_sizef;

--- a/contrib/gtnap/src/gtnap/gtnap.c
+++ b/contrib/gtnap/src/gtnap/gtnap.c
@@ -737,8 +737,8 @@ static void i_create_fonts2(const real32_t size, const real32_t width, GtNap *gt
     cassert_no_null(gtnap);
     ptr_destopt(font_destroy, &gtnap->global_font, Font);
     ptr_destopt(font_destroy, &gtnap->reduced_font, Font);
-    gtnap->global_font = font_monospace(size, 0);
-    gtnap->reduced_font = font_monospace(rsize, 0);
+    gtnap->global_font = font_monospace(size, ekFCELL);
+    gtnap->reduced_font = font_monospace(rsize, ekFCELL);
     font_set_width(gtnap->global_font, width);
     font_set_width(gtnap->reduced_font, rwidth);
 }

--- a/contrib/gtnap/src/gui/tableview.c
+++ b/contrib/gtnap/src/gui/tableview.c
@@ -690,7 +690,10 @@ static void i_col_y_offset(Column *col, const uint32_t row_height)
     case ekCTYPE_TEXT:
     {
         uint32_t height = i_font_height(col->font);
-        col->yoffset = (row_height - height) / 2;
+        if (row_height > height)
+            col->yoffset = (row_height - height) / 2;
+        else
+            col->yoffset = 0;
         break;
     }
 


### PR DESCRIPTION
* Support for GTNAP build issues.
* Clone GTWVW font metrics and window dimensioning.
* Testing GTNAP/CUADEMO PaiWindowNum issue.
* Implement NAppGUI font create using cell size `ekFCELL`.
* Implement NAppGUI `font_set_width()` to allow the text to be widened and narrowed.